### PR TITLE
Non-standard (boolean) cast is deprecated in PHP 8.5. Use (bool) instead

### DIFF
--- a/src/Commands/ValidateCommand.php
+++ b/src/Commands/ValidateCommand.php
@@ -306,7 +306,7 @@ final class ValidateCommand extends Command
         $validateArchive = $input->getOption('validate-git-archive');
         $globPattern = $input->getOption('glob-pattern');
         $globPatternFile = (string) $input->getOption('glob-pattern-file');
-        $omitHeader = (boolean) $input->getOption('omit-header');
+        $omitHeader = (bool) $input->getOption('omit-header');
         $showDifference = $input->getOption('diff');
         $reportStaleExportIgnores = $input->getOption('report-stale-export-ignores');
 
@@ -343,7 +343,7 @@ final class ValidateCommand extends Command
             $this->analyser->enableStrictAlignmentComparison();
         }
 
-        $keepLicense = (boolean) $input->getOption('keep-license');
+        $keepLicense = (bool) $input->getOption('keep-license');
 
         if ($keepLicense) {
             $verboseOutput = '+ Keeping the license file.';
@@ -352,7 +352,7 @@ final class ValidateCommand extends Command
             $this->analyser->keepLicense();
         }
 
-        $keepReadme = (boolean) $input->getOption('keep-readme');
+        $keepReadme = (bool) $input->getOption('keep-readme');
 
         if ($keepReadme) {
             $verboseOutput = '+ Keeping the README file.';


### PR DESCRIPTION
Fixes ` Non-standard (boolean) cast` (reported by phpstan)


```
./vendor/bin/phpstan
Note: Using configuration file /home/sasezaki/dev/lean-package-validator/phpstan.neon.dist.
 54/54 [▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓] 100%

 ------ ---------------------------------------------------------------------------
  Line   src/Commands/ValidateCommand.php
 ------ ---------------------------------------------------------------------------
  309    Non-standard (boolean) cast is deprecated in PHP 8.5. Use (bool) instead.
         🪪  cast.deprecated
  346    Non-standard (boolean) cast is deprecated in PHP 8.5. Use (bool) instead.
         🪪  cast.deprecated
  355    Non-standard (boolean) cast is deprecated in PHP 8.5. Use (bool) instead.
         🪪  cast.deprecated
 ------ ---------------------------------------------------------------------------
```

<!-- RECURSEML_SUMMARY:START -->
## High-level PR Summary
This PR updates deprecated `(boolean)` type casts to the standard `(bool)` syntax to maintain compatibility with PHP 8.5. Three instances in the `ValidateCommand` class are updated where option values are cast to boolean types for `omit-header`, `keep-license`, and `keep-readme` options.

⏱️ Estimated Review Time: 5-15 minutes

<details>
<summary>💡 Review Order Suggestion</summary>

| Order | File Path |
|-------|-----------|
| 1 | `src/Commands/ValidateCommand.php` |
</details>



[![Need help? Join our Discord](https://img.shields.io/badge/Need%20help%3F%20Join%20our%20Discord-5865F2?style=plastic&logo=discord&logoColor=white)](https://discord.gg/n3SsVDAW6U)

<!-- RECURSEML_SUMMARY:END -->