### PR TITLE
Add Symfony 8 support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,8 +14,8 @@
         "ergebnis/agent-detector": "^1.0",
         "sebastian/diff": "^7.0.0||^6.0.1||^5.0||^4.0.3",
         "stolt/list-skills-command": "^1.0",
-        "symfony/console": "^7.2.1||^v5.4.8",
-        "symfony/finder": "^7.2.1||^v5.4.8"
+        "symfony/console": "^8.0||^7.2.1||^v5.4.8",
+        "symfony/finder": "^8.0||^7.2.1||^v5.4.8"
     },
     "autoload": {
         "psr-4": {
@@ -75,7 +75,7 @@
     "require-dev": {
         "carthage-software/mago": "^1.18.0",
         "mockery/mockery": "^1.0",
-        "peckphp/peck": "^0.2.0",
+        "peckphp/peck": "^0.2.0||^0.3.0",
         "phlak/semver": "^4.1 || ^6.0",
         "php-mock/php-mock": "^2.6",
         "php-mock/php-mock-phpunit": "^2.7||^1.1",

--- a/tests/Commands/ValidateCommandStdinOptionsTest.php
+++ b/tests/Commands/ValidateCommandStdinOptionsTest.php
@@ -44,7 +44,7 @@ final class ValidateCommandStdinOptionsTest extends TestCase
             new Validator(new Archive($this->temporaryDirectory)),
             $fakeInputReader
         );
-        $application->add($command);
+        $application->addCommands([$command]);
 
         return [$application, $command];
     }

--- a/tests/Commands/ValidateCommandTest.php
+++ b/tests/Commands/ValidateCommandTest.php
@@ -2301,7 +2301,7 @@ CONTENT;
             $fakeInputReader
         );
 
-        $application->add($analyserCommand);
+        $application->addCommands([$analyserCommand]);
         $command = $application->find('validate');
 
         $expectedDisplay = <<<CONTENT
@@ -2356,7 +2356,7 @@ CONTENT;
             $fakeInputReader
         );
 
-        $application->add($analyserCommand);
+        $application->addCommands([$analyserCommand]);
         $command = $application->find('validate');
 
         $expectedDisplay = <<<CONTENT
@@ -2444,7 +2444,7 @@ CONTENT;
             new FakeInputReader()
         );
 
-        $application->add($analyserCommand);
+        $application->addCommands([$analyserCommand]);
 
         return $application;
     }
@@ -2463,7 +2463,7 @@ CONTENT;
             new FakeInputReader()
         );
 
-        $application->add($analyserCommand);
+        $application->addCommands([$analyserCommand]);
 
         return $application;
     }

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -153,7 +153,7 @@ class TestCase extends PHPUnit
     protected function getApplication(Command $command): Application
     {
         $application = new Application();
-        $application->add($command);
+        $application->addCommands([$command]);
 
         return $application;
     }


### PR DESCRIPTION
Closes #66.

- Widen `symfony/console` and `symfony/finder` to include `^8.0`.
- Bump `peckphp/peck` floor to allow `^0.3.0` (Symfony 8 compatible).
- Replace removed `Application::add()` with `addCommands([...])` (compatible from Symfony 5.x onward).

Tests pass on Symfony 7.4.8 and 8.0.8 (171/171, 365 assertions).

<!-- RECURSEML_SUMMARY:START -->
## High-level PR Summary
This PR adds support for Symfony 8 by widening dependency constraints for `symfony/console` and `symfony/finder` to include `^8.0`, updating the dev dependency `peckphp/peck` to allow `^0.3.0`, and replacing the deprecated `Application::add()` method with `addCommands()` throughout the test suite (a change compatible from Symfony 5.x onward).

⏱️ Estimated Review Time: 5-15 minutes

<details>
<summary>💡 Review Order Suggestion</summary>

| Order | File Path |
|-------|-----------|
| 1 | `composer.json` |
| 2 | `tests/TestCase.php` |
| 3 | `tests/Commands/ValidateCommandStdinOptionsTest.php` |
| 4 | `tests/Commands/ValidateCommandTest.php` |
</details>



[![Need help? Join our Discord](https://img.shields.io/badge/Need%20help%3F%20Join%20our%20Discord-5865F2?style=plastic&logo=discord&logoColor=white)](https://discord.gg/n3SsVDAW6U)

<!-- RECURSEML_SUMMARY:END -->